### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.2](https://github.com/jdx/vfox.rs/compare/v0.1.1..v0.1.2) - 2024-08-18
+
+### 🐛 Bug Fixes
+
+- working with more plugins by [@jdx](https://github.com/jdx) in [8c37c7c](https://github.com/jdx/vfox.rs/commit/8c37c7c2f8e40c448cc25618b566c533c8d66f2d)
+
 ## [0.1.1](https://github.com/jdx/vfox.rs/compare/v0.1.0..v0.1.1) - 2024-08-18
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [0.1.2](https://github.com/jdx/vfox.rs/compare/v0.1.1..v0.1.2) - 2024-08-18

### 🐛 Bug Fixes

- working with more plugins by [@jdx](https://github.com/jdx) in [8c37c7c](https://github.com/jdx/vfox.rs/commit/8c37c7c2f8e40c448cc25618b566c533c8d66f2d)