### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.5](https://github.com/jdx/vfox.rs/compare/v0.1.4..v0.1.5) - 2024-10-14
+
+### 🐛 Bug Fixes
+
+- windows bug by [@jdx](https://github.com/jdx) in [a1ff24a](https://github.com/jdx/vfox.rs/commit/a1ff24aff5fb16582011a8e0db0aa2d436780524)
+
 ## [0.1.4](https://github.com/jdx/vfox.rs/compare/v0.1.3..v0.1.4) - 2024-10-14
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,7 +2414,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [0.1.5](https://github.com/jdx/vfox.rs/compare/v0.1.4..v0.1.5) - 2024-10-14

### 🐛 Bug Fixes

- windows bug by [@jdx](https://github.com/jdx) in [a1ff24a](https://github.com/jdx/vfox.rs/commit/a1ff24aff5fb16582011a8e0db0aa2d436780524)