### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1](https://github.com/jdx/vfox.rs/compare/v0.2.0..v0.2.1) - 2024-10-26
+
+### 🐛 Bug Fixes
+
+- added "send" feature to mlua by [@jdx](https://github.com/jdx) in [49cef81](https://github.com/jdx/vfox.rs/commit/49cef815ac946ee93af016d42751ce25e1fc65ce)
+
 ## [0.2.0](https://github.com/jdx/vfox.rs/compare/v0.1.6..v0.2.0) - 2024-10-26
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [0.2.1](https://github.com/jdx/vfox.rs/compare/v0.2.0..v0.2.1) - 2024-10-26

### 🐛 Bug Fixes

- added "send" feature to mlua by [@jdx](https://github.com/jdx) in [49cef81](https://github.com/jdx/vfox.rs/commit/49cef815ac946ee93af016d42751ce25e1fc65ce)