### PR TITLE
Remove `dbg!` from `mise_path` plugin to reduce noise

### DIFF
--- a/src/hooks/mise_path.rs
+++ b/src/hooks/mise_path.rs
@@ -21,7 +21,6 @@ impl Plugin {
                 return PLUGIN:MisePath($ctx)
             })
             .await?;
-        dbg!(&path);
 
         Ok(path)
     }


### PR DESCRIPTION
I'm testing the new `env`-only plugin in Mise and every time the Mise hook evaluates (i.e. after every command), following line is displayed in the shell:
```
[/Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-6f17d22bba15001f/vfox-0.2.1/src/hooks/mise_path.rs:24:9] &path = []
```