### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.2](https://github.com/jdx/vfox.rs/compare/v0.3.1..v0.3.2) - 2024-11-11
+
+### 🐛 Bug Fixes
+
+- increase html parser limit by [@jdx](https://github.com/jdx) in [1bae49d](https://github.com/jdx/vfox.rs/commit/1bae49dc01fa82c7c7344972c80647390eb4ced7)
+- set OS_TYPE,ARCH_TYPE by [@jdx](https://github.com/jdx) in [9851ae2](https://github.com/jdx/vfox.rs/commit/9851ae2c607adf39b798da525949285bdcb31774)
+- added more runtime config by [@jdx](https://github.com/jdx) in [#59](https://github.com/jdx/vfox.rs/pull/59)
+
+### 🔍 Other Changes
+
+- updated deps by [@jdx](https://github.com/jdx) in [7b6a78b](https://github.com/jdx/vfox.rs/commit/7b6a78b432beee7575163864875377e56c6669c1)
+
 ## [0.3.1](https://github.com/jdx/vfox.rs/compare/v0.3.0..v0.3.1) - 2024-11-06
 
 ### 🔍 Other Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2255,7 +2255,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [0.3.2](https://github.com/jdx/vfox.rs/compare/v0.3.1..v0.3.2) - 2024-11-11

### 🐛 Bug Fixes

- increase html parser limit by [@jdx](https://github.com/jdx) in [1bae49d](https://github.com/jdx/vfox.rs/commit/1bae49dc01fa82c7c7344972c80647390eb4ced7)
- set OS_TYPE,ARCH_TYPE by [@jdx](https://github.com/jdx) in [9851ae2](https://github.com/jdx/vfox.rs/commit/9851ae2c607adf39b798da525949285bdcb31774)
- added more runtime config by [@jdx](https://github.com/jdx) in [#59](https://github.com/jdx/vfox.rs/pull/59)

### 🔍 Other Changes

- updated deps by [@jdx](https://github.com/jdx) in [7b6a78b](https://github.com/jdx/vfox.rs/commit/7b6a78b432beee7575163864875377e56c6669c1)