### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.0.0](https://github.com/jdx/vfox.rs/compare/v0.3.5..1.0.0) - 2025-01-09
+## [1.0.1](https://github.com/jdx/vfox.rs/compare/v1.0.0..v1.0.1) - 2025-02-02
+
+### 🔍 Other Changes
+
+- bump xx by [@jdx](https://github.com/jdx) in [1871b1b](https://github.com/jdx/vfox.rs/commit/1871b1bc64009dc4071e797a7c3856c34a24e569)
+
+## [1.0.0](https://github.com/jdx/vfox.rs/compare/v0.3.5..v1.0.0) - 2025-01-09
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [1.0.1](https://github.com/jdx/vfox.rs/compare/v1.0.0..v1.0.1) - 2025-02-02

### 🔍 Other Changes

- bump xx by [@jdx](https://github.com/jdx) in [1871b1b](https://github.com/jdx/vfox.rs/commit/1871b1bc64009dc4071e797a7c3856c34a24e569)