### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.2](https://github.com/jdx/vfox.rs/compare/v1.0.1..v1.0.2) - 2025-05-06
+
+### 🔍 Other Changes
+
+- lock mlua to 0.10.3 for now by [@jdx](https://github.com/jdx) in [a6ef55c](https://github.com/jdx/vfox.rs/commit/a6ef55c721b0d9618ff41546e4979e2e605af334)
+
 ## [1.0.1](https://github.com/jdx/vfox.rs/compare/v1.0.0..v1.0.1) - 2025-02-02
 
 ### 🔍 Other Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vfox"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 description = "Interface to vfox plugins"


### PR DESCRIPTION
## [1.0.2](https://github.com/jdx/vfox.rs/compare/v1.0.1..v1.0.2) - 2025-05-06

### 🔍 Other Changes

- lock mlua to 0.10.3 for now by [@jdx](https://github.com/jdx) in [a6ef55c](https://github.com/jdx/vfox.rs/commit/a6ef55c721b0d9618ff41546e4979e2e605af334)