### PR TITLE
fix: support capital HTML tags

### DIFF
--- a/lua/htmlparser/ElementNode.lua
+++ b/lua/htmlparser/ElementNode.lua
@@ -156,7 +156,7 @@ function ElementNode:close(closestart, closeend)
 		node = node.parent
 		if not node then break end
 		node.deepernodes:add(self)
-		insert(node.deeperelements, self.name, self)
+		insert(node.deeperelements, string.lower(self.name), self)
 		for k in pairs(self.attributes) do
 			insert(node.deeperattributes, k, self)
 		end

--- a/src/lua_mod/html.rs
+++ b/src/lua_mod/html.rs
@@ -79,7 +79,7 @@ mod tests {
         lua.load(mlua::chunk! {
             local html = require("html")
             local doc = html.parse("<html><body><div id='t2' name='123'>456</div><DIV foo='bar'>222</DIV></body></html>")
-            local f = doc:find("DIV"):eq(0)
+            local f = doc:find("div"):eq(0)
             local s = doc:find("div"):eq(1)
             assert(s:text() == "222")
             assert(f:text() == "456")

--- a/src/lua_mod/html.rs
+++ b/src/lua_mod/html.rs
@@ -78,8 +78,8 @@ mod tests {
         mod_html(&lua).unwrap();
         lua.load(mlua::chunk! {
             local html = require("html")
-            local doc = html.parse("<html><body><div id='t2' name='123'>456</div><div foo='bar'>222</div></body></html>")
-            local f = doc:find("div"):eq(0)
+            local doc = html.parse("<html><body><div id='t2' name='123'>456</div><DIV foo='bar'>222</DIV></body></html>")
+            local f = doc:find("DIV"):eq(0)
             local s = doc:find("div"):eq(1)
             assert(s:text() == "222")
             assert(f:text() == "456")


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/5373#discussioncomment-13595423.

This allows `doc:find("div")` to find `<DIV>` tags, but `doc:find("DIV")` still cannot find `<div>` tags.
I think it will be great if we can support it, but I gave up as I didn't find any simple fixes for it.
Also, I don't think it's a common usecase.